### PR TITLE
feat: pass ctx to challange and add before hook

### DIFF
--- a/challenge/interface.go
+++ b/challenge/interface.go
@@ -1,6 +1,8 @@
 package challenge
 
+import "context"
+
 type IChallenge interface {
-	Solve(body map[string]interface{}) (*map[string]interface{}, error)
-	Request(body map[string]interface{}) (*map[string]interface{}, error) // Request a challenge, ex: for OTP you have to request an OTP before you can solve it
+	Solve(ctx context.Context, body map[string]interface{}) (*map[string]interface{}, error)
+	Request(ctx context.Context, body map[string]interface{}) (*map[string]interface{}, error) // Request a challenge, ex: for OTP you have to request an OTP before you can solve it
 }

--- a/examples/single_flow_multiple_challenges/challenges/dummy.go
+++ b/examples/single_flow_multiple_challenges/challenges/dummy.go
@@ -1,6 +1,7 @@
 package challenges
 
 import (
+	"context"
 	"errors"
 	"log"
 	"math/rand"
@@ -25,7 +26,7 @@ type DummyChallenge struct {
 	Seed string `json:"seed"`
 }
 
-func (c *DummyChallenge) Solve(body map[string]interface{}) (*map[string]interface{}, error) {
+func (c *DummyChallenge) Solve(ctx context.Context, body map[string]interface{}) (*map[string]interface{}, error) {
 	log.Println("seed:", c.Seed)
 	log.Println("password:", body["password"])
 	if body["username"] == "admin" && body["password"].(string) == c.Seed {
@@ -34,7 +35,7 @@ func (c *DummyChallenge) Solve(body map[string]interface{}) (*map[string]interfa
 	return nil, errors.New("failed!")
 }
 
-func (c *DummyChallenge) Request(body map[string]interface{}) (*map[string]interface{}, error) {
+func (c *DummyChallenge) Request(ctx context.Context, body map[string]interface{}) (*map[string]interface{}, error) {
 	rand.Seed(time.Now().UnixNano())
 	c.Seed = randSeq(10)
 	log.Println("Seed:", c.Seed)

--- a/examples/single_flow_multiple_challenges/challenges/dummy2.go
+++ b/examples/single_flow_multiple_challenges/challenges/dummy2.go
@@ -1,6 +1,7 @@
 package challenges
 
 import (
+	"context"
 	"errors"
 	"log"
 	"math/rand"
@@ -15,7 +16,7 @@ type DummyTwoChallenge struct {
 	Seed string `json:"seed"`
 }
 
-func (c *DummyTwoChallenge) Solve(body map[string]interface{}) (*map[string]interface{}, error) {
+func (c *DummyTwoChallenge) Solve(ctx context.Context, body map[string]interface{}) (*map[string]interface{}, error) {
 	log.Println("seed:", c.Seed)
 	log.Println("password:", body["password"])
 	if body["username"] == "admin" && body["password"].(string) == c.Seed {
@@ -24,7 +25,7 @@ func (c *DummyTwoChallenge) Solve(body map[string]interface{}) (*map[string]inte
 	return nil, errors.New("failed!")
 }
 
-func (c *DummyTwoChallenge) Request(body map[string]interface{}) (*map[string]interface{}, error) {
+func (c *DummyTwoChallenge) Request(ctx context.Context, body map[string]interface{}) (*map[string]interface{}, error) {
 	rand.Seed(time.Now().UnixNano())
 	c.Seed = randSeq(10)
 	log.Println("Seed:", c.Seed)

--- a/examples/single_flow_multiple_challenges/mfa.go
+++ b/examples/single_flow_multiple_challenges/mfa.go
@@ -44,7 +44,7 @@ func main() {
 	log.Println(fail)
 
 	jwt = res.Token
-	res, err = mfaService.Process(context.TODO(), jwt, "dummy", fail, false)
+	res, err = mfaService.Process(context.TODO(), jwt, "dummy", fail, false, nil)
 	if err != nil {
 		log.Println("Failed")
 	}
@@ -52,7 +52,7 @@ func main() {
 	log.Println(string(resJSON))
 
 	jwt = res.Token
-	res, err = mfaService.Process(context.TODO(), jwt, "dummy", pass, false)
+	res, err = mfaService.Process(context.TODO(), jwt, "dummy", pass, false, nil)
 	if err != nil {
 		log.Println("Failed")
 	}
@@ -60,7 +60,7 @@ func main() {
 	log.Println(string(resJSON))
 
 	jwt = res.Token
-	res, err = mfaService.Process(context.TODO(), jwt, "dummy2", pass, true)
+	res, err = mfaService.Process(context.TODO(), jwt, "dummy2", pass, true, nil)
 	if err != nil {
 		log.Println("Failed")
 	}
@@ -72,7 +72,7 @@ func main() {
 	log.Println(pass)
 	log.Println(fail)
 
-	res, err = mfaService.Process(context.TODO(), jwt, "dummy2", pass, false)
+	res, err = mfaService.Process(context.TODO(), jwt, "dummy2", pass, false, nil)
 	if err != nil {
 		log.Println("Failed")
 	}

--- a/examples/single_flow_single_challenge/challenges/dummy.go
+++ b/examples/single_flow_single_challenge/challenges/dummy.go
@@ -1,6 +1,7 @@
 package challenges
 
 import (
+	"context"
 	"errors"
 	"log"
 	"math/rand"
@@ -25,7 +26,7 @@ type DummyChallenge struct {
 	Seed string `json:"seed"`
 }
 
-func (c *DummyChallenge) Solve(body map[string]interface{}) (*map[string]interface{}, error) {
+func (c *DummyChallenge) Solve(ctx context.Context, body map[string]interface{}) (*map[string]interface{}, error) {
 	log.Println("seed:", c.Seed)
 	log.Println("password:", body["password"])
 	if body["username"] == "admin" && body["password"].(string) == c.Seed {
@@ -34,7 +35,7 @@ func (c *DummyChallenge) Solve(body map[string]interface{}) (*map[string]interfa
 	return nil, errors.New("failed!")
 }
 
-func (c *DummyChallenge) Request(body map[string]interface{}) (*map[string]interface{}, error) {
+func (c *DummyChallenge) Request(ctx context.Context, body map[string]interface{}) (*map[string]interface{}, error) {
 	rand.Seed(time.Now().UnixNano())
 	c.Seed = randSeq(10)
 	log.Println("Seed:", c.Seed)

--- a/examples/single_flow_single_challenge/mfa.go
+++ b/examples/single_flow_single_challenge/mfa.go
@@ -48,7 +48,7 @@ func main() {
 	log.Println(fail)
 
 	// Attempt to solve
-	res, err = mfaService.Process(context.TODO(), jwt, "dummy", fail, false)
+	res, err = mfaService.Process(context.TODO(), jwt, "dummy", fail, false, nil)
 	if err != nil {
 		log.Println("Failed")
 	}
@@ -56,7 +56,7 @@ func main() {
 	log.Println(string(resJSON))
 	jwt = res.Token
 
-	res, err = mfaService.Process(context.TODO(), jwt, "dummy", pass, false)
+	res, err = mfaService.Process(context.TODO(), jwt, "dummy", pass, false, nil)
 	if err != nil {
 		log.Println("Failed")
 	}

--- a/flow/entities/flow.go
+++ b/flow/entities/flow.go
@@ -1,6 +1,7 @@
 package entities
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -17,27 +18,27 @@ func (f Flow) GetName() string {
 	return f.Name
 }
 
-func (f Flow) Solve(challenge string, input string, JWTData mfaEntities.JWTData) (*map[string]interface{}, error) {
+func (f Flow) Solve(ctx context.Context, challenge string, input string, JWTData mfaEntities.JWTData) (*map[string]interface{}, error) {
 	var marshaledInput map[string]interface{}
 	err := json.Unmarshal([]byte(input), &marshaledInput)
 	if err != nil {
 		return nil, err
 	}
 	if challenge, ok := f.Challenges[challenge]; ok {
-		return challenge.Solve(marshaledInput)
+		return challenge.Solve(ctx, marshaledInput)
 	}
 
 	return nil, errors.New("Challenge not found")
 }
 
-func (f Flow) Request(challenge string, input string, JWTData mfaEntities.JWTData) (*map[string]interface{}, error) {
+func (f Flow) Request(ctx context.Context, challenge string, input string, JWTData mfaEntities.JWTData) (*map[string]interface{}, error) {
 	var marshaledInput map[string]interface{}
 	err := json.Unmarshal([]byte(input), &marshaledInput)
 	if err != nil {
 		return nil, err
 	}
 	if challenge, ok := f.Challenges[challenge]; ok {
-		return challenge.Request(marshaledInput)
+		return challenge.Request(ctx, marshaledInput)
 	}
 
 	return nil, errors.New("Challenge not found")

--- a/flow/entities/flow_test.go
+++ b/flow/entities/flow_test.go
@@ -1,6 +1,7 @@
 package entities_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -44,9 +45,9 @@ func TestFlow_GetChallenges(t *testing.T) {
 			},
 		}
 
-		dummyChallenge.EXPECT().Solve(gomock.Any()).Return(nil, nil)
+		dummyChallenge.EXPECT().Solve(gomock.Any(), gomock.Any()).Return(nil, nil)
 
-		solved, err := flow.Solve("dummy", "{}", mfaEntities.JWTData{
+		solved, err := flow.Solve(context.TODO(), "dummy", "{}", mfaEntities.JWTData{
 			Flow: "test",
 			Challenges: map[string]mfaEntities.Challenge{
 				"dummy": {
@@ -71,9 +72,9 @@ func TestFlow_GetChallenges(t *testing.T) {
 			},
 		}
 
-		dummyChallenge.EXPECT().Solve(gomock.Any()).Return(nil, errors.New("error"))
+		dummyChallenge.EXPECT().Solve(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
-		solved, err := flow.Solve("dummy", "{}", mfaEntities.JWTData{
+		solved, err := flow.Solve(context.TODO(), "dummy", "{}", mfaEntities.JWTData{
 			Flow: "test",
 			Challenges: map[string]mfaEntities.Challenge{
 				"dummy": {
@@ -98,7 +99,7 @@ func TestFlow_GetChallenges(t *testing.T) {
 			},
 		}
 
-		solved, err := flow.Solve("dummy", "", mfaEntities.JWTData{
+		solved, err := flow.Solve(context.TODO(), "dummy", "", mfaEntities.JWTData{
 			Flow: "test",
 			Challenges: map[string]mfaEntities.Challenge{
 				"dummy": {
@@ -123,7 +124,7 @@ func TestFlow_GetChallenges(t *testing.T) {
 			},
 		}
 
-		solved, err := flow.Solve("dummy2", "{}", mfaEntities.JWTData{
+		solved, err := flow.Solve(context.TODO(), "dummy2", "{}", mfaEntities.JWTData{
 			Flow: "test",
 			Challenges: map[string]mfaEntities.Challenge{
 				"dummy": {
@@ -148,9 +149,9 @@ func TestFlow_GetChallenges(t *testing.T) {
 			},
 		}
 
-		dummyChallenge.EXPECT().Request(gomock.Any()).Return(nil, nil)
+		dummyChallenge.EXPECT().Request(gomock.Any(), gomock.Any()).Return(nil, nil)
 
-		reqested, err := flow.Request("dummy", "{}", mfaEntities.JWTData{
+		reqested, err := flow.Request(context.TODO(), "dummy", "{}", mfaEntities.JWTData{
 			Flow: "test",
 			Challenges: map[string]mfaEntities.Challenge{
 				"dummy": {
@@ -176,7 +177,7 @@ func TestFlow_GetChallenges(t *testing.T) {
 			},
 		}
 
-		reqested, err := flow.Request("dummy2", "{}", mfaEntities.JWTData{
+		reqested, err := flow.Request(context.TODO(), "dummy2", "{}", mfaEntities.JWTData{
 			Flow: "test",
 			Challenges: map[string]mfaEntities.Challenge{
 				"dummy": {
@@ -203,7 +204,7 @@ func TestFlow_GetChallenges(t *testing.T) {
 			},
 		}
 
-		reqested, err := flow.Request("dummy", "", mfaEntities.JWTData{
+		reqested, err := flow.Request(context.TODO(), "dummy", "", mfaEntities.JWTData{
 			Flow: "test",
 			Challenges: map[string]mfaEntities.Challenge{
 				"dummy": {

--- a/flow/interface.go
+++ b/flow/interface.go
@@ -8,8 +8,8 @@ import (
 )
 
 type IFlow interface {
-	Solve(challenge string, input string, JWTData mfaEntities.JWTData) (*map[string]interface{}, error)
-	Request(challenge string, input string, JWTData mfaEntities.JWTData) (*map[string]interface{}, error)
+	Solve(ctx context.Context, challenge string, input string, JWTData mfaEntities.JWTData) (*map[string]interface{}, error)
+	Request(ctx context.Context, challenge string, input string, JWTData mfaEntities.JWTData) (*map[string]interface{}, error)
 	Resolve(JWTData mfaEntities.JWTData) (*map[string]interface{}, error)
 	Validate(ctx context.Context, challenge string, JWTData mfaEntities.JWTData) error
 	GetChallenges() []string

--- a/mfa/interface.go
+++ b/mfa/interface.go
@@ -8,5 +8,5 @@ import (
 
 type IMFAService interface {
 	Request(ctx context.Context, flow string) (*entities.MFAResult, error)
-	Process(ctx context.Context, jwt string, challenge string, input string, request bool) (*entities.MFAResult, error)
+	Process(ctx context.Context, jwt string, challenge string, input string, request bool, beforeHook *func(ctx context.Context, challenge string, input string) error) (*entities.MFAResult, error)
 }

--- a/mfa/mfa_test.go
+++ b/mfa/mfa_test.go
@@ -56,7 +56,7 @@ func TestNewMFAService(t *testing.T) {
 
 		jwtService.EXPECT().GenerateToken(gomock.Any(), gomock.Any()).Return(validJWT, nil)
 
-		mockflow.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockflow.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 		mockflow.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockflow.EXPECT().GetName().Return("test")
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
@@ -68,7 +68,7 @@ func TestNewMFAService(t *testing.T) {
 
 		mfaService := mfa.NewMFAService(config, jwtService, flowMap)
 
-		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", true)
+		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", true, nil)
 
 		nullMetadata := "null"
 		expectedResult := entities.MFAResult{
@@ -95,7 +95,7 @@ func TestNewMFAService(t *testing.T) {
 
 		mfaService := mfa.NewMFAService(config, jwtService, flowMap)
 
-		result, err := mfaService.Process(context.TODO(), "", "dummy", "{}", true)
+		result, err := mfaService.Process(context.TODO(), "", "dummy", "{}", true, nil)
 
 		a.Error(err)
 		a.Equal("Invalid JWT", err.Error())
@@ -116,7 +116,7 @@ func TestNewMFAService(t *testing.T) {
 
 		mfaService := mfa.NewMFAService(config, jwtService, flowMap)
 
-		result, err := mfaService.Process(context.TODO(), invalidJWT, "dummy", "{}", true)
+		result, err := mfaService.Process(context.TODO(), invalidJWT, "dummy", "{}", true, nil)
 
 		a.Error(err)
 		a.Equal("unexpected end of JSON input", err.Error())
@@ -137,7 +137,7 @@ func TestNewMFAService(t *testing.T) {
 
 		jwtService.EXPECT().GenerateToken(gomock.Any(), gomock.Any()).Return(validJWT, nil)
 
-		mockflow.EXPECT().Solve(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockflow.EXPECT().Solve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 		mockflow.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockflow.EXPECT().GetName().Return("test")
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
@@ -148,7 +148,7 @@ func TestNewMFAService(t *testing.T) {
 
 		mfaService := mfa.NewMFAService(config, jwtService, flowMap)
 
-		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", false)
+		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", false, nil)
 
 		nullMetadata := "null"
 		expectedResult := entities.MFAResult{
@@ -174,7 +174,7 @@ func TestNewMFAService(t *testing.T) {
 
 		jwtService.EXPECT().GenerateToken(gomock.Any(), gomock.Any()).Return(validJWT, nil)
 
-		mockflow.EXPECT().Solve(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("Failed to solve"))
+		mockflow.EXPECT().Solve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("Failed to solve"))
 		mockflow.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockflow.EXPECT().GetName().Return("test")
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
@@ -182,7 +182,7 @@ func TestNewMFAService(t *testing.T) {
 
 		mfaService := mfa.NewMFAService(config, jwtService, flowMap)
 
-		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", false)
+		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", false, nil)
 
 		expectedResult := entities.MFAResult{
 			Token:      validJWT,
@@ -208,7 +208,7 @@ func TestNewMFAService(t *testing.T) {
 
 		jwtService.EXPECT().GenerateToken(gomock.Any(), gomock.Any()).Return(validJWT, nil)
 
-		mockflow.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any()).Return(&map[string]interface{}{
+		mockflow.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&map[string]interface{}{
 			"Reference": "test",
 		}, nil)
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
@@ -251,7 +251,7 @@ func TestNewMFAService(t *testing.T) {
 
 		jwtService.EXPECT().GenerateToken(gomock.Any(), gomock.Any()).Return(validJWT, nil)
 
-		mockflow.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("Failed to handle challenge"))
+		mockflow.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("Failed to handle challenge"))
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
 		mockflow.EXPECT().GetName().Return("test")
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
@@ -304,7 +304,7 @@ func TestNewMFAService(t *testing.T) {
 			},
 		}, gomock.Any()).Return(validJWT, nil)
 
-		mockflow.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockflow.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
 		mockflow.EXPECT().GetName().Return("test")
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
@@ -358,7 +358,7 @@ func TestNewMFAService(t *testing.T) {
 
 		jwtService.EXPECT().GenerateToken(gomock.Any(), gomock.Any()).Return(validJWT, nil)
 
-		mockflow.EXPECT().Solve(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockflow.EXPECT().Solve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 		mockflow.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockflow.EXPECT().GetName().Return("test")
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
@@ -367,7 +367,7 @@ func TestNewMFAService(t *testing.T) {
 
 		mfaService := mfa.NewMFAService(config, jwtService, flowMap)
 
-		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", false)
+		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", false, nil)
 
 		nullMetadata := "null"
 		expectedResult := entities.MFAResult{
@@ -394,7 +394,7 @@ func TestNewMFAService(t *testing.T) {
 
 		jwtService.EXPECT().GenerateToken(gomock.Any(), gomock.Any()).Return(validJWT, nil)
 
-		mockflow.EXPECT().Solve(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockflow.EXPECT().Solve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 		mockflow.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockflow.EXPECT().GetName().Return("test")
 		mockflow.EXPECT().GetChallenges().Return([]string{"dummy"})
@@ -403,7 +403,7 @@ func TestNewMFAService(t *testing.T) {
 
 		mfaService := mfa.NewMFAService(config, jwtService, flowMap)
 
-		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", false)
+		result, err := mfaService.Process(context.TODO(), validJWT, "dummy", "{}", false, nil)
 
 		nullMetadata := "null"
 		expectedResult := entities.MFAResult{

--- a/mocks/mock_challenge.go
+++ b/mocks/mock_challenge.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -34,31 +35,31 @@ func (m *MockIChallenge) EXPECT() *MockIChallengeMockRecorder {
 }
 
 // Request mocks base method.
-func (m *MockIChallenge) Request(arg0 map[string]interface{}) (*map[string]interface{}, error) {
+func (m *MockIChallenge) Request(arg0 context.Context, arg1 map[string]interface{}) (*map[string]interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Request", arg0)
+	ret := m.ctrl.Call(m, "Request", arg0, arg1)
 	ret0, _ := ret[0].(*map[string]interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Request indicates an expected call of Request.
-func (mr *MockIChallengeMockRecorder) Request(arg0 interface{}) *gomock.Call {
+func (mr *MockIChallengeMockRecorder) Request(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockIChallenge)(nil).Request), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockIChallenge)(nil).Request), arg0, arg1)
 }
 
 // Solve mocks base method.
-func (m *MockIChallenge) Solve(arg0 map[string]interface{}) (*map[string]interface{}, error) {
+func (m *MockIChallenge) Solve(arg0 context.Context, arg1 map[string]interface{}) (*map[string]interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Solve", arg0)
+	ret := m.ctrl.Call(m, "Solve", arg0, arg1)
 	ret0, _ := ret[0].(*map[string]interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Solve indicates an expected call of Solve.
-func (mr *MockIChallengeMockRecorder) Solve(arg0 interface{}) *gomock.Call {
+func (mr *MockIChallengeMockRecorder) Solve(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Solve", reflect.TypeOf((*MockIChallenge)(nil).Solve), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Solve", reflect.TypeOf((*MockIChallenge)(nil).Solve), arg0, arg1)
 }

--- a/mocks/mock_flow.go
+++ b/mocks/mock_flow.go
@@ -80,18 +80,18 @@ func (mr *MockIFlowMockRecorder) Initialize(arg0 interface{}) *gomock.Call {
 }
 
 // Request mocks base method.
-func (m *MockIFlow) Request(arg0, arg1 string, arg2 entities0.JWTData) (*map[string]interface{}, error) {
+func (m *MockIFlow) Request(arg0 context.Context, arg1, arg2 string, arg3 entities0.JWTData) (*map[string]interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Request", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Request", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*map[string]interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Request indicates an expected call of Request.
-func (mr *MockIFlowMockRecorder) Request(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockIFlowMockRecorder) Request(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockIFlow)(nil).Request), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockIFlow)(nil).Request), arg0, arg1, arg2, arg3)
 }
 
 // Resolve mocks base method.
@@ -110,18 +110,18 @@ func (mr *MockIFlowMockRecorder) Resolve(arg0 interface{}) *gomock.Call {
 }
 
 // Solve mocks base method.
-func (m *MockIFlow) Solve(arg0, arg1 string, arg2 entities0.JWTData) (*map[string]interface{}, error) {
+func (m *MockIFlow) Solve(arg0 context.Context, arg1, arg2 string, arg3 entities0.JWTData) (*map[string]interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Solve", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Solve", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*map[string]interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Solve indicates an expected call of Solve.
-func (mr *MockIFlowMockRecorder) Solve(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockIFlowMockRecorder) Solve(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Solve", reflect.TypeOf((*MockIFlow)(nil).Solve), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Solve", reflect.TypeOf((*MockIFlow)(nil).Solve), arg0, arg1, arg2, arg3)
 }
 
 // Validate mocks base method.


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

### Description

* Challenges need access to context to get some data like the identifier
* Additionally if the identifier does not match the challenge requirements, we should be able to add to the context that the challenge can then use.

ex: We pass in mobile number for initializing auth flow, cardPIN service however needs a userid. To achieve this we need to pass ctx to the challenge and use the before hook to add data to the ctx for the challenge to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/mfa-lib/10)
<!-- Reviewable:end -->
